### PR TITLE
Implement Nil check on Model.MoveToNext()

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,6 +89,9 @@ func New() *Model {
 
 func (m *Model) MoveToNext() tea.Msg {
 	selectedItem := m.lists[m.focused].SelectedItem()
+	if selectedItem == nil {
+		return nil
+	}
 	selectedTask := selectedItem.(Task)
 	m.lists[selectedTask.status].RemoveItem(m.lists[m.focused].Index())
 	selectedTask.Next()


### PR DESCRIPTION
## About This PR

Fix the error that program panics when trying to move item, but item list is empty.


## Error Screenshot

<img width="1832" alt="image" src="https://github.com/1eedaegon/tui-kanban/assets/32592965/c8661ff6-d554-4c1c-a4a3-6fd383c93704">

## Error Log

```
panic: interface conversion: list.Item is nil, not main.Task

goroutine 5 [running]:
main.(*Model).MoveToNext(0x140000e2000)
        /Users/lee/programming/tui-kanban/main.go:92 +0x298
github.com/charmbracelet/bubbletea.(*Program).handleCommands.func1.1()
        /Users/lee/go/pkg/mod/github.com/charmbracelet/bubbletea@v0.24.1/tea.go:268 +0x34
created by github.com/charmbracelet/bubbletea.(*Program).handleCommands.func1 in goroutine 39
        /Users/lee/go/pkg/mod/github.com/charmbracelet/bubbletea@v0.24.1/tea.go:267 +0x110
```